### PR TITLE
Add Huggingface wrapper of Model/Datasets

### DIFF
--- a/fusionlab/classification/__init__.py
+++ b/fusionlab/classification/__init__.py
@@ -1,8 +1,9 @@
 from fusionlab.configs import BACKEND
 if BACKEND == 'torch':
-    from .base import CNNClassification, RNNClassification
+    from .base import CNNClassification, RNNClassification, HFClassification
     from .lstm import LSTMClassifier
     from .vgg import VGG16Classifier, VGG19Classifier
+    from .base import HFSegmentationModel
 elif BACKEND == 'tf':
     print('not built yet')
 else:

--- a/fusionlab/classification/__init__.py
+++ b/fusionlab/classification/__init__.py
@@ -1,9 +1,9 @@
 from fusionlab.configs import BACKEND
 if BACKEND == 'torch':
-    from .base import CNNClassification, RNNClassification, HFClassification
+    from .base import CNNClassificationModel, RNNClassificationModel, HFClassificationModel
     from .lstm import LSTMClassifier
     from .vgg import VGG16Classifier, VGG19Classifier
-    from .base import HFSegmentationModel
+    from .base import HFClassificationModel
 elif BACKEND == 'tf':
     print('not built yet')
 else:

--- a/fusionlab/classification/base.py
+++ b/fusionlab/classification/base.py
@@ -3,7 +3,7 @@
 
 import torch.nn as nn
 
-class CNNClassification(nn.Module):
+class CNNClassificationModel(nn.Module):
     """
     Base PyTorch class of the classification model with Encoder, Head for CNN
     """
@@ -18,7 +18,7 @@ class CNNClassification(nn.Module):
         output = self.head(features_agg.view(x.shape[0],-1)) # => [BATCH, NUM_CLS]
         return output
 
-class RNNClassification(nn.Module):
+class RNNClassificationModel(nn.Module):
     """
     Base PyTorch class of the classification model with Encoder, Head for RNN
     """
@@ -29,7 +29,7 @@ class RNNClassification(nn.Module):
         output = self.head(features[:, -1, :])
         return output
 
-class HFClassification(nn.Module):
+class HFClassificationModel(nn.Module):
     """
     Base Hugginface-pytoch model wrapper class of the classification model
     """
@@ -61,8 +61,8 @@ if __name__ == '__main__':
     cout = 5
     inputs = torch.normal(0, 1, (1, 3, W))
     # Test CNNClassification
-    model = VGG16Classifier(3, cout, spatial_dims=2)
-    hf_model = HFClassification(model, cout)
+    model = VGG16Classifier(3, cout, spatial_dims=1)
+    hf_model = HFClassificationModel(model, cout)
     output = hf_model(inputs)
     print(output['logits'].shape)
     assert list(output.keys()) == ['loss', 'logits', 'hidden_states']
@@ -70,14 +70,14 @@ if __name__ == '__main__':
     inputs = torch.normal(0, 1, (1, 3, H, W))
     # Test CNNClassification
     model = VGG16Classifier(3, cout, spatial_dims=2)
-    hf_model = HFClassification(model, cout)
+    hf_model = HFClassificationModel(model, cout)
     output = hf_model(inputs)
     print(output['logits'].shape)
     assert list(output.keys()) == ['loss', 'logits', 'hidden_states']
 
     inputs = torch.normal(0, 1, (1, 3, H))
     model = LSTMClassifier(3, cout)
-    hf_model = HFClassification(model, cout)
+    hf_model = HFClassificationModel(model, cout)
     output = hf_model(inputs)
     print(output['logits'].shape)
     assert list(output.keys()) == ['loss', 'logits', 'hidden_states']

--- a/fusionlab/classification/base.py
+++ b/fusionlab/classification/base.py
@@ -8,10 +8,14 @@ class CNNClassification(nn.Module):
     Base PyTorch class of the classification model with Encoder, Head for CNN
     """
     def forward(self, x):
-        x_T = x.transpose(-1,-2) # Transpose [BATCH, TIME, CHANNEL] => [BATCH, CHANNEL, TIME]
-        features = self.encoder(x_T) # => [BATCH, 512, TIME]
-        features_agg = self.globalpooling(features) # => [BATCH, 512, 1]
-        output = self.head(features_agg[:, :, -1])
+        # 1D signal x => [BATCH, CHANNEL, TIME]
+        # 1D spectrum x => [BATCH, FREQUENCY, TIME] (single channel)
+        # 2D spectrum x => [BATCH, CHANNEL, FREQUENCY, TIME] (multi channel)
+        # 2D image x => [BATCH, CHANNEL, HEIGHT, WIDTH]
+        # 3D volumetric x => [BATCH, CHANNEL, HEIGHT, WIDTH, DEPTH]
+        features = self.encoder(x) # => [BATCH, 512, ...]
+        features_agg = self.globalpooling(features) # => [BATCH, 512, 1, (1, (1))]
+        output = self.head(features_agg.view(x.shape[0],-1)) # => [BATCH, NUM_CLS]
         return output
 
 class RNNClassification(nn.Module):
@@ -19,6 +23,8 @@ class RNNClassification(nn.Module):
     Base PyTorch class of the classification model with Encoder, Head for RNN
     """
     def forward(self, x):
+        # 1D signal x => [BATCH, CHANNEL, TIME]
+        x = x.transpose(1,2)
         features, _ = self.encoder(x) # RNN will output feature and states
         output = self.head(features[:, -1, :])
         return output
@@ -30,6 +36,7 @@ class HFClassification(nn.Module):
     def __init__(self, model,
                  num_cls=4,
                  loss_fct=nn.CrossEntropyLoss()):
+        super().__init__()
         self.net = model
         self.num_cls = num_cls
         self.loss_fct = loss_fct
@@ -48,12 +55,29 @@ class HFClassification(nn.Module):
 if __name__ == '__main__':
     import torch
     from fusionlab.classification import VGG16Classifier
+    from fusionlab.classification import LSTMClassifier
+
     H = W = 224
     cout = 5
-    inputs = torch.normal(0, 1, (1, 3, H, W))
-
+    inputs = torch.normal(0, 1, (1, 3, W))
     # Test CNNClassification
-    model = VGG16Classifier(spatial_dims=3, 3, cout, 64)
-    hf_model = HFSegmentationModel(model, cout)
+    model = VGG16Classifier(3, cout, spatial_dims=2)
+    hf_model = HFClassification(model, cout)
     output = hf_model(inputs)
+    print(output['logits'].shape)
+    assert list(output.keys()) == ['loss', 'logits', 'hidden_states']
+
+    inputs = torch.normal(0, 1, (1, 3, H, W))
+    # Test CNNClassification
+    model = VGG16Classifier(3, cout, spatial_dims=2)
+    hf_model = HFClassification(model, cout)
+    output = hf_model(inputs)
+    print(output['logits'].shape)
+    assert list(output.keys()) == ['loss', 'logits', 'hidden_states']
+
+    inputs = torch.normal(0, 1, (1, 3, H))
+    model = LSTMClassifier(3, cout)
+    hf_model = HFClassification(model, cout)
+    output = hf_model(inputs)
+    print(output['logits'].shape)
     assert list(output.keys()) == ['loss', 'logits', 'hidden_states']

--- a/fusionlab/classification/base.py
+++ b/fusionlab/classification/base.py
@@ -22,3 +22,38 @@ class RNNClassification(nn.Module):
         features, _ = self.encoder(x) # RNN will output feature and states
         output = self.head(features[:, -1, :])
         return output
+
+class HFClassification(nn.Module):
+    """
+    Base Hugginface-pytoch model wrapper class of the classification model
+    """
+    def __init__(self, model,
+                 num_cls=4,
+                 loss_fct=nn.CrossEntropyLoss()):
+        self.net = model
+        self.num_cls = num_cls
+        self.loss_fct = loss_fct
+    def forward(self, x, labels=None):
+        logits = self.net(x)  # Forward pass the model
+        if labels is not None:
+            # logits => [BATCH, NUM_CLS]
+            # labels => [BATCH]
+            loss = self.loss_fct(logits.view(-1, self.num_cls), labels.view(-1))  # Calculate loss
+        else:
+            loss = None
+        # return dictionary for hugginface trainer
+        return {'loss':loss, 'logits':logits, 'hidden_states':None}
+
+# Test the function
+if __name__ == '__main__':
+    import torch
+    from fusionlab.classification import VGG16Classifier
+    H = W = 224
+    cout = 5
+    inputs = torch.normal(0, 1, (1, 3, H, W))
+
+    # Test CNNClassification
+    model = VGG16Classifier(spatial_dims=3, 3, cout, 64)
+    hf_model = HFSegmentationModel(model, cout)
+    output = hf_model(inputs)
+    assert list(output.keys()) == ['loss', 'logits', 'hidden_states']

--- a/fusionlab/classification/lstm.py
+++ b/fusionlab/classification/lstm.py
@@ -1,9 +1,9 @@
 import torch
 from torch import nn
-from fusionlab.classification.base import RNNClassification
+from fusionlab.classification.base import RNNClassificationModel
 
 
-class LSTMClassifier(RNNClassification):
+class LSTMClassifier(RNNClassificationModel):
     def __init__(self, cin, cout, hidden_size=512):
         super().__init__()
         self.encoder = nn.LSTM(input_size=cin, hidden_size=hidden_size, batch_first=True) # define LSTM layer

--- a/fusionlab/classification/vgg.py
+++ b/fusionlab/classification/vgg.py
@@ -6,27 +6,29 @@ from fusionlab.encoders import VGG16, VGG19
 from fusionlab.layers import AdaptiveAvgPool
 
 class VGG16Classifier(CNNClassification):
-    def __init__(self, spatial_dims, cin, cout):
+    def __init__(self, cin, cout, spatial_dims=2):
         super().__init__()
-        self.encoder = VGG16(spatial_dims, cin) # Create VGG16 instance
+        self.cout = cout
+        self.encoder = VGG16(cin, spatial_dims) # Create VGG16 instance
         self.globalpooling = AdaptiveAvgPool(spatial_dims, 1)
         self.head = nn.Linear(512, cout)
 
 class VGG19Classifier(CNNClassification):
-    def __init__(self, spatial_dims, cin, cout):
+    def __init__(self, cin, cout, spatial_dims=2):
         super().__init__()
-        self.encoder = VGG19(spatial_dims, cin) # Create VGG16 instance
+        self.cout = cout
+        self.encoder = VGG19(cin, spatial_dims) # Create VGG16 instance
         self.globalpooling = AdaptiveAvgPool(spatial_dims, 1)
         self.head = nn.Linear(512, cout)
 
 
 if __name__ == '__main__':
     inputs = torch.randn(1, 224, 3) # create random input tensor
-    model = VGG16Classifier(spatial_dims=1, cin=3, cout=2) # create model instance
+    model = VGG16Classifier(cin=3, cout=2, spatial_dims=1) # create model instance
     outputs = model(inputs) # pass input through model
     assert list(outputs.shape) == [1, 2] # check output shape is correct
 
     inputs = torch.randn(1, 224, 3) # create random input tensor
-    model = VGG19Classifier(spatial_dims=1,cin=3, cout=2) # create model instance
+    model = VGG19Classifier(cin=3, cout=2, spatial_dims=1) # create model instance
     outputs = model(inputs) # pass input through model
     assert list(outputs.shape) == [1, 2] # check output shape is correct

--- a/fusionlab/classification/vgg.py
+++ b/fusionlab/classification/vgg.py
@@ -1,11 +1,11 @@
 # VGG Classifier
 import torch
 from torch import nn
-from fusionlab.classification.base import CNNClassification
+from fusionlab.classification.base import CNNClassificationModel
 from fusionlab.encoders import VGG16, VGG19
 from fusionlab.layers import AdaptiveAvgPool
 
-class VGG16Classifier(CNNClassification):
+class VGG16Classifier(CNNClassificationModel):
     def __init__(self, cin, cout, spatial_dims=2):
         super().__init__()
         self.cout = cout
@@ -13,7 +13,7 @@ class VGG16Classifier(CNNClassification):
         self.globalpooling = AdaptiveAvgPool(spatial_dims, 1)
         self.head = nn.Linear(512, cout)
 
-class VGG19Classifier(CNNClassification):
+class VGG19Classifier(CNNClassificationModel):
     def __init__(self, cin, cout, spatial_dims=2):
         super().__init__()
         self.cout = cout

--- a/fusionlab/datasets/__init__.py
+++ b/fusionlab/datasets/__init__.py
@@ -12,7 +12,10 @@ if BACKEND == 'torch':
         LUDBDataset,
         plot
     )
-    from .utils import download_file 
+    from .utils import (
+        download_file,
+        HFDataset,
+    ) 
 elif BACKEND == 'tf':
     print('not built yet')
 else:

--- a/fusionlab/datasets/utils.py
+++ b/fusionlab/datasets/utils.py
@@ -1,6 +1,5 @@
+import torch
 from torchvision.datasets.utils import download_and_extract_archive, download_url
-
-
 import os
 from typing import Optional
 
@@ -29,3 +28,16 @@ def download_file(url: str,
         if extract_root is None:  # if extract_root is not provided
             extract_root = download_root  # set extract_root to download_root
         download_and_extract_archive(url, download_root, extract_root, filename=filename)  # download and extract the file to extract_root
+
+class HFDataset(torch.utils.data.Dataset):
+    """
+    Base Hugginface dataset wrapper class
+    Args:
+        dataset: a dataset object that contains a getitem method
+    """
+    def __init__(self, dataset):
+        super().__init__()
+        self.dataset = dataset
+    def __getitem__(self, index):
+        x, labels = self.dataset[index]  # Forward pass the dataset
+        return {'x': x, 'labels': labels}

--- a/fusionlab/datasets/utils.py
+++ b/fusionlab/datasets/utils.py
@@ -41,3 +41,19 @@ class HFDataset(torch.utils.data.Dataset):
     def __getitem__(self, index):
         x, labels = self.dataset[index]  # Forward pass the dataset
         return {'x': x, 'labels': labels}
+
+# Testing
+def __main__():
+    NUM_DATA = 20
+    NUM_FEATURES = 16
+    ds = torch.utils.data.TensorDataset(
+        torch.zeros(NUM_DATA, NUM_FEATURES),
+        torch.zeros(NUM_DATA))
+    for x, y in ds:
+        assert list(x.shape) == [NUM_FEATURES]
+        pass
+    hf_ds = HFDataset(ds)
+    for data_dict in hf_ds:
+        assert list(data_dict.keys) == ['x', 'labels']
+        assert list(data_dict['x'].shape) == [NUM_FEATURES]
+        pass

--- a/fusionlab/encoders/alexnet/alexnet.py
+++ b/fusionlab/encoders/alexnet/alexnet.py
@@ -4,7 +4,7 @@ from fusionlab.layers.factories import ConvND, MaxPool
 
 # Official pytorch ref: https://github.com/pytorch/vision/blob/main/torchvision/models/alexnet.py
 class AlexNet(nn.Module):
-    def __init__(self, spatial_dims=2, cin=3):
+    def __init__(self, cin=3, spatial_dims=2):
         super().__init__()
         self.features = nn.Sequential(
             ConvND(spatial_dims, cin, 64, kernel_size=11, stride=4, padding=2),

--- a/fusionlab/encoders/inceptionv1/inceptionv1.py
+++ b/fusionlab/encoders/inceptionv1/inceptionv1.py
@@ -39,7 +39,7 @@ class InceptionBlock(nn.Module):
 
 
 class InceptionNetV1(nn.Module):
-    def __init__(self, spatial_dims=2, cin=3):
+    def __init__(self, cin=3, spatial_dims=2):
         super().__init__()
         self.stem = nn.Sequential(
             ConvBlock(cin, 64, 7, spatial_dims, stride=2),

--- a/fusionlab/encoders/resnetv1/resnetv1.py
+++ b/fusionlab/encoders/resnetv1/resnetv1.py
@@ -63,7 +63,7 @@ class StageBlock(nn.Sequential):
 
 
 class ResNet50V1(nn.Module):
-    def __init__(self, spatial_dims=2, cin=3):
+    def __init__(self, cin=3, spatial_dims=2):
         super().__init__()
         self.conv1 = Stem(cin, spatial_dims)
         self.conv2 = nn.Sequential(

--- a/fusionlab/encoders/vgg/vgg.py
+++ b/fusionlab/encoders/vgg/vgg.py
@@ -4,7 +4,7 @@ from fusionlab.layers import ConvND, MaxPool
 
 # Official pytorch ref: https://github.com/pytorch/vision/blob/main/torchvision/models/vgg.py
 class VGG16(nn.Module):
-    def __init__(self, spatial_dims=2, cin=3):
+    def __init__(self, cin=3, spatial_dims=2):
         super().__init__()
         ksize = 3
         self.features = nn.Sequential(
@@ -50,7 +50,7 @@ class VGG16(nn.Module):
 
 
 class VGG19(nn.Module):
-    def __init__(self, spatial_dims=2, cin=3):
+    def __init__(self, cin=3, spatial_dims=2):
         super().__init__()
         ksize = 3
         self.features = nn.Sequential(
@@ -106,24 +106,24 @@ class VGG19(nn.Module):
 if __name__ == '__main__':
     # VGG16
     inputs = torch.normal(0, 1, (1, 3, 224))
-    output = VGG16(spatial_dims=1, cin=3)(inputs)
+    output = VGG16(cin=3, spatial_dims=1)(inputs)
     shape = list(output.shape)
     assert shape[2:] == [7]
 
     # VGG19
     inputs = torch.normal(0, 1, (1, 3, 224))
-    output = VGG19(spatial_dims=1, cin=3)(inputs)
+    output = VGG19(cin=3, spatial_dims=1)(inputs)
     shape = list(output.shape)
     assert shape[2:] == [7]
 
     # VGG16
     inputs = torch.normal(0, 1, (1, 3, 224, 224))
-    output = VGG16(spatial_dims=2, cin=3)(inputs)
+    output = VGG16(cin=3,  spatial_dims=2)(inputs)
     shape = list(output.shape)
     assert shape[2:] == [7, 7]
 
     # VGG19
     inputs = torch.normal(0, 1, (1, 3, 224, 224))
-    output = VGG19(spatial_dims=2, cin=3)(inputs)
+    output = VGG19(cin=3,  spatial_dims=2)(inputs)
     shape = list(output.shape)
     assert shape[2:] == [7, 7]

--- a/fusionlab/segmentation/__init__.py
+++ b/fusionlab/segmentation/__init__.py
@@ -3,6 +3,7 @@ if BACKEND == 'torch':
     from .unet.unet import UNet
     from .resunet.resunet import ResUNet
     from .unet2plus.unet2plus import UNet2plus
+    from .base import HFSegmentationModel
 elif BACKEND == 'tf':
     from .unet.tfunet import TFUNet
     from .resunet.tfresunet import TFResUNet

--- a/releas_logs.md
+++ b/releas_logs.md
@@ -1,3 +1,0 @@
-0.0.52
-
-* Tversky Loss for Torch and TF

--- a/release_logs.md
+++ b/release_logs.md
@@ -1,0 +1,3 @@
+0.0.52
+
+* Tversky Loss for Torch and TF


### PR DESCRIPTION
Huggingface wrapper for Dataset:
e.g.
``` python
from fusionlab.datasets import LUDBDataset, HFDataset
ds = LUDBDataset("./data", "./data/ludb_annotation.json")  # initiate dataset object

hf_ds = HFDataset(ds)  # wrap

# use it as hugginface dataset with ...
# output dictionary:
#     {'x', 'labels'}  (data like signal/image/spectrum, labels like class/segmentation map)
for data_dict in hf_ds:
  ...
  # for torch model
  pred = model(data_dict['x'])
  loss = loss_function(pred , data_dict['labels'])

  # for hf model 
  output_dict = hf_model(data_dict)
```

Huggingface wrapper for model:
e.g.
``` python
from torch import nn
from fusionlab.classification import VGG16Classifier, HFClassificationModel
NUM_CLASS = 5
model = VGG16Classifier(cin=3, cout=NUM_CLASS, spatial_dims=1)  # initiate model object

hf_model = HFClassificationModel(model, num_cls=NUM_CLASS,  loss_fct=nn.CrossEntropyLoss())   # wrap

# use it as hugginface model with ...
# input kwargs:
#     x, labels  (data and label)
# output dictionary:
#     {'loss', 'logits', 'hidden_states'}  (loss, model output, hiddenstate is dummy)
output_dict = hf_model(data_dict)
```